### PR TITLE
Add version number to the addon

### DIFF
--- a/client/ayon_openrv/addon.py
+++ b/client/ayon_openrv/addon.py
@@ -2,6 +2,7 @@ import os
 
 from ayon_core.addon import AYONAddon, IHostAddon, IPluginPaths
 
+from .version import __version__
 
 OPENRV_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -9,6 +10,7 @@ OPENRV_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 class OpenRVAddon(AYONAddon, IHostAddon, IPluginPaths):
     name = "openrv"
     host_name = "openrv"
+    version = __version__
 
     def initialize(self, module_settings):
         self.enabled = True

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 name = "openrv"
 title = "OpenRV"
-version = "1.0.1-dev.1"
+version = "1.0.1-dev.2"
 
 client_dir = "ayon_openrv"
 


### PR DESCRIPTION
## Changes

Addon was missing version number from the package, resulting in a warning message durin AYON startup: `DEV WARNING: Addon 'openrv' does not have defined version.`