### PR TITLE
Fix: required context to launch app

### DIFF
--- a/client/ayon_openrv/plugins/load/global/play_in_rv.py
+++ b/client/ayon_openrv/plugins/load/global/play_in_rv.py
@@ -53,9 +53,7 @@ class PlayInRV(load.LoaderPlugin):
             # launch RV with context
             ctx = {
                 "project_name": project_name,
-                "folder_entity": folder_entity,
                 "folder_path": folder_path,
-                "task_entity": task_entity,
                 "task_name": task_entity["name"]
             }
 

--- a/client/ayon_openrv/plugins/load/global/play_in_rv.py
+++ b/client/ayon_openrv/plugins/load/global/play_in_rv.py
@@ -1,5 +1,6 @@
 import json
 
+import ayon_api
 from ayon_applications import ApplicationManager
 
 from ayon_core.pipeline import load
@@ -11,7 +12,11 @@ from ayon_openrv.networking import RVConnector
 
 
 class PlayInRV(load.LoaderPlugin):
-    """Open Image Sequence with system default"""
+    """Opens representation with network connected OpenRV
+
+    Could be run from Loader in DCC or outside.
+    It expects to be run only on representations published to any task!
+    """
 
     product_types = {"*"}
     representations = {"*"}
@@ -29,27 +34,48 @@ class PlayInRV(load.LoaderPlugin):
         rvcon = RVConnector()
 
         if not rvcon.is_connected:
-            app_manager = ApplicationManager()
-
             # get launch context variables
-            task = context["representation"]["data"]["context"].get("task")
-            folder_path = context["folder"].get("path")
-            if not all([folder_path, task]):
-                raise Exception(f"Missing context data: {folder_path = }, {task = }")
+            project_name = context["project"]["name"]
+
+            task_entity = None
+            task_id = context["version"]["taskId"]
+            # could be published without task from Publisher
+            if task_id:
+                task_entity = ayon_api.get_task_by_id(project_name, task_id)
+
+            folder_entity = context["folder"]
+            folder_path = folder_entity.get("path")
+            # check required for host launch
+            if not all([folder_path, task_entity]):
+                raise Exception(f"Missing context data: {folder_path = }, "
+                                f"{task_entity = }")
 
             # launch RV with context
             ctx = {
-                "project_name": context["project"]["name"],
+                "project_name": project_name,
+                "folder_entity": folder_entity,
                 "folder_path": folder_path,
-                "task_name": task["name"] or "generic",
+                "task_entity": task_entity,
+                "task_name": task_entity["name"]
             }
+
+            app_manager = ApplicationManager()
             openrv_app = app_manager.find_latest_available_variant_for_group("openrv")
+            if not openrv_app:
+                raise RuntimeError(
+                    f"No configured OpenRV found in "
+                    f"Applications. Ask admin to configure it "
+                    f"in ayon+settings://applications/applications/openrv.\n"
+                    f"Provide '-network' there as argument."
+                )
             openrv_app.launch(**ctx)
 
+        repre_ext = context["representation"]["context"]["representation"]
         _data = [{
-            "objectName": context["representation"]["context"]["representation"],
+            "objectName": repre_ext,
             "representation": context["representation"]["id"],
         }]
         payload = json.dumps(_data)
         with rvcon: # this also retries the connection
-            rvcon.send_event("ayon_load_container", payload, shall_return=False)
+            rvcon.send_event(
+                "ayon_load_container", payload, shall_return=False)


### PR DESCRIPTION
`folder_entity` and `task_entity` is required to launch host app.

Test notes:
- configure OpenRV in Applications (don't forget `-network` in Arguments)
- run `Play in RV` on represenation (which was ordinary published with task)