### PR TITLE
Open in RV action: Enhance loader handling

### DIFF
--- a/client/ayon_openrv/plugins/load/global/play_in_rv.py
+++ b/client/ayon_openrv/plugins/load/global/play_in_rv.py
@@ -45,10 +45,10 @@ class PlayInRV(load.LoaderPlugin):
             )
             if not openrv_app:
                 raise LoadError(
-                    f"No configured OpenRV found in"
-                    f" Applications. Ask admin to configure it"
-                    f" in ayon+settings://applications/applications/openrv."
-                    f"\nProvide '-network' there as argument."
+                    "No configured OpenRV found in"
+                    " Applications. Ask admin to configure it"
+                    " in ayon+settings://applications/applications/openrv."
+                    "\nProvide '-network' there as argument."
                 )
             openrv_app.launch(
                 project_name=project_name,

--- a/client/ayon_openrv/plugins/load/global/play_in_rv.py
+++ b/client/ayon_openrv/plugins/load/global/play_in_rv.py
@@ -3,10 +3,11 @@ import json
 import ayon_api
 from ayon_applications import ApplicationManager
 
-from ayon_core.pipeline import load
 from ayon_core.lib.transcoding import (
     IMAGE_EXTENSIONS, VIDEO_EXTENSIONS
 )
+from ayon_core.pipeline import load
+from ayon_core.pipeline.load import LoadError
 
 from ayon_openrv.networking import RVConnector
 
@@ -32,48 +33,78 @@ class PlayInRV(load.LoaderPlugin):
 
     def load(self, context, name, namespace, data):
         rvcon = RVConnector()
-
         if not rvcon.is_connected:
             # get launch context variables
-            project_name = context["project"]["name"]
-
-            task_entity = None
-            task_id = context["version"]["taskId"]
-            # could be published without task from Publisher
-            if task_id:
-                task_entity = ayon_api.get_task_by_id(project_name, task_id)
-
-            folder_entity = context["folder"]
-            folder_path = folder_entity.get("path")
-            # check required for host launch
-            if not all([folder_path, task_entity]):
-                raise Exception(f"Missing context data: {folder_path = }, "
-                                f"{task_entity = }")
-
+            project_name, folder_path, task_name = (
+                self._get_lauch_context(context)
+            )
             # launch RV with context
-            ctx = {
-                "project_name": project_name,
-                "folder_path": folder_path,
-                "task_name": task_entity["name"]
-            }
-
             app_manager = ApplicationManager()
-            openrv_app = app_manager.find_latest_available_variant_for_group("openrv")
+            openrv_app = app_manager.find_latest_available_variant_for_group(
+                "openrv"
+            )
             if not openrv_app:
-                raise RuntimeError(
-                    f"No configured OpenRV found in "
-                    f"Applications. Ask admin to configure it "
-                    f"in ayon+settings://applications/applications/openrv.\n"
-                    f"Provide '-network' there as argument."
+                raise LoadError(
+                    f"No configured OpenRV found in"
+                    f" Applications. Ask admin to configure it"
+                    f" in ayon+settings://applications/applications/openrv."
+                    f"\nProvide '-network' there as argument."
                 )
-            openrv_app.launch(**ctx)
+            openrv_app.launch(
+                project_name=project_name,
+                folder_path=folder_path,
+                task_name=task_name
+            )
 
-        repre_ext = context["representation"]["context"]["representation"]
-        _data = [{
-            "objectName": repre_ext,
+        payload = json.dumps([{
+            "objectName": context["representation"]["name"],
             "representation": context["representation"]["id"],
-        }]
-        payload = json.dumps(_data)
-        with rvcon: # this also retries the connection
+        }])
+        # This also retries the connection
+        with rvcon:
             rvcon.send_event(
-                "ayon_load_container", payload, shall_return=False)
+                "ayon_load_container",
+                payload,
+                shall_return=False
+            )
+
+    def _get_lauch_context(self, context):
+        # get launch context variables
+        project_name = context["project"]["name"]
+
+        folder_entity = context["folder"]
+        folder_path = folder_entity.get("path")
+        if not folder_path:
+            raise LoadError(
+                "Selected representation does not have available folder."
+                " It is not possible to start OpenRV."
+            )
+
+        task_entity = None
+        task_id = context["version"]["taskId"]
+        # could be published without task from Publisher
+        if task_id:
+            task_entity = ayon_api.get_task_by_id(project_name, task_id)
+
+        if not task_entity:
+            repre_context = context["representation"]["context"]
+            task_info = repre_context.get("task")
+            task_name = None
+            if task_info:
+                if isinstance(task_info, str):
+                    task_name = task_info
+                elif isinstance(task_info, dict):
+                    task_name = task_info.get("name")
+
+            if task_name:
+                task_entity = ayon_api.get_task_by_name(
+                    project_name, folder_entity["id"], task_name
+                )
+
+        if task_entity:
+            return project_name, folder_path, task_entity["name"]
+
+        raise LoadError(
+            "Selected representation does not have available task."
+            " It is not possible to start OpenRV."
+        )


### PR DESCRIPTION
## Description
Add more options to get task for older versions (using representation context). And raise human readable errors with `LoadError` exception.

## Additional information
Older versions don't have filled `taskId`. Task information is in that case available only on representation context where is task name.

Errors raised when context was invalid were so cryptic that no-one from tested subjects understood what just happened. Also not using `LoadError` caused that the traceback is shown, which scares people thinking it's a bug.

## Testing notes
1. Run `"Open in RV"` on representation without filled task on version.
2. It should use task from representation and continue as it would be ok.
3. If task is not on representation either then it should show error dialog without traceback.