### PR TITLE
Remove deprecated ImageIOConfigModel and `ocio_config` settings

### DIFF
--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -24,16 +24,8 @@ class ImageIOSettings(BaseSettingsModel):
     activate_host_color_management: bool = SettingsField(
         True, title="Enable Color Management"
     )
-    ocio_config: ImageIOConfigModel = SettingsField(
-        default_factory=ImageIOConfigModel,
-        title="OCIO config"
-    )
 
 
 DEFAULT_IMAGEIO_SETTINGS = {
     "activate_host_color_management": True,
-    "ocio_config": {
-        "override_global_config": False,
-        "filepath": []
-    },
 }


### PR DESCRIPTION
## Changelog Description

Remove deprecated `ocio_config` `ImageIOConfigModel` settings

## Additional info

With [the support of profiles to determine OCIO config in ayon-core](https://github.com/ynput/ayon-core/pull/490) this logic has been superseded and should be removed from each addon still having the deprecated settings.

Related to https://github.com/ynput/ayon-core/issues/785