### PR TITLE
Remove OpenPype and avalon references

### DIFF
--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -75,7 +75,13 @@ class OpenRVHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         imprint("root", data, prefix=AYON_ATTR_PREFIX)
 
     def get_context_data(self):
-        return read("root", prefix=AYON_ATTR_PREFIX)
+        context_data = read("root", prefix=AYON_ATTR_PREFIX)
+        if not context_data:
+            # lets try backward compatibility
+            # TODO: remove later
+            context_data = read("root", prefix="openpype.")
+
+        return context_data
 
 
 def imprint(node, data, prefix=None):

--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -181,7 +181,7 @@ def imprint_container(node, name, namespace, context, loader):
     """
 
     data = [
-        ("schema", "openpype:container-2.0"),
+        ("schema", "ayon:container-2.0"),
         ("id", str(AYON_CONTAINER_ID)),
         ("name", str(name)),
         ("namespace", str(namespace)),

--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 import json
-from collections import OrderedDict
 
 import pyblish
 import rv

--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -231,6 +231,13 @@ def get_container_nodes():
         prop = f"{node}.{AYON_ATTR_PREFIX}schema"
         if rv.commands.propertyExists(prop):
             container_nodes.append(node)
+        else:
+            # lets try backward compatibility
+            # TODO: remove later
+            prop = f"{node}.openpype.schema"
+            if rv.commands.propertyExists(prop):
+                container_nodes.append(node)
+
     return container_nodes
 
 

--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -31,7 +31,7 @@ class OpenRVHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def __init__(self):
         super(OpenRVHost, self).__init__()
-        self._op_events = {}
+        self._ay_events = {}
 
     def install(self):
         pyblish.api.register_plugin_path(PUBLISH_PATH)

--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -13,7 +13,7 @@ from ayon_core.pipeline import (
     register_loader_plugin_path,
     register_inventory_action_path,
     register_creator_plugin_path,
-    AVALON_CONTAINER_ID,
+    AYON_CONTAINER_ID,
 )
 
 PLUGINS_DIR = os.path.join(OPENRV_ROOT_DIR, "plugins")
@@ -49,11 +49,7 @@ class OpenRVHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def work_root(self, session):
         work_dir = session.get("AYON_WORKDIR")
-        scene_dir = session.get("AVALON_SCENEDIR")
-        if scene_dir:
-            return os.path.join(work_dir, scene_dir)
-        else:
-            return work_dir
+        return work_dir
 
     def get_current_workfile(self):
         filename = rv.commands.sessionFileName()
@@ -186,7 +182,7 @@ def imprint_container(node, name, namespace, context, loader):
 
     data = [
         ("schema", "openpype:container-2.0"),
-        ("id", str(AVALON_CONTAINER_ID)),
+        ("id", str(AYON_CONTAINER_ID)),
         ("name", str(name)),
         ("namespace", str(namespace)),
         ("loader", str(loader)),

--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -22,7 +22,7 @@ LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
 CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
 INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
-OPENPYPE_ATTR_PREFIX = "openpype."
+AYON_ATTR_PREFIX = "ayon."
 JSON_PREFIX = "JSON:::"
 
 
@@ -72,10 +72,10 @@ class OpenRVHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             yield container
 
     def update_context_data(self, data, changes):
-        imprint("root", data, prefix=OPENPYPE_ATTR_PREFIX)
+        imprint("root", data, prefix=AYON_ATTR_PREFIX)
 
     def get_context_data(self):
-        return read("root", prefix=OPENPYPE_ATTR_PREFIX)
+        return read("root", prefix=AYON_ATTR_PREFIX)
 
 
 def imprint(node, data, prefix=None):
@@ -193,7 +193,7 @@ def imprint_container(node, name, namespace, context, loader):
     # are always created in the same order. This is solely
     # to make debugging easier when reading the values in
     # the attribute editor.
-    imprint(node, OrderedDict(data), prefix=OPENPYPE_ATTR_PREFIX)
+    imprint(node, OrderedDict(data), prefix=AYON_ATTR_PREFIX)
 
 
 def parse_container(node):
@@ -208,7 +208,7 @@ def parse_container(node):
 
     data = {}
     for key in required:
-        prop = f"{node}.{OPENPYPE_ATTR_PREFIX}{key}"
+        prop = f"{node}.{AYON_ATTR_PREFIX}{key}"
         if not rv.commands.propertyExists(prop):
             return
 
@@ -228,7 +228,7 @@ def get_container_nodes():
     """Return a list of node names that are marked as loaded container."""
     container_nodes = []
     for node in rv.commands.nodes():
-        prop = f"{node}.{OPENPYPE_ATTR_PREFIX}schema"
+        prop = f"{node}.{AYON_ATTR_PREFIX}schema"
         if rv.commands.propertyExists(prop):
             container_nodes.append(node)
     return container_nodes

--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -180,20 +180,16 @@ def imprint_container(node, name, namespace, context, loader):
 
     """
 
-    data = [
-        ("schema", "ayon:container-2.0"),
-        ("id", str(AYON_CONTAINER_ID)),
-        ("name", str(name)),
-        ("namespace", str(namespace)),
-        ("loader", str(loader)),
-        ("representation", str(context["representation"]["id"]))
-    ]
+    data = {
+        "schema": "ayon:container-2.0",
+        "id": str(AYON_CONTAINER_ID),
+        "name": str(name),
+        "namespace": str(namespace),
+        "loader": str(loader),
+        "representation": str(context["representation"]["id"])
+    }
 
-    # We use an OrderedDict to make sure the attributes
-    # are always created in the same order. This is solely
-    # to make debugging easier when reading the values in
-    # the attribute editor.
-    imprint(node, OrderedDict(data), prefix=AYON_ATTR_PREFIX)
+    imprint(node, data, prefix=AYON_ATTR_PREFIX)
 
 
 def parse_container(node):
@@ -210,7 +206,11 @@ def parse_container(node):
     for key in required:
         prop = f"{node}.{AYON_ATTR_PREFIX}{key}"
         if not rv.commands.propertyExists(prop):
-            return
+            # lets try backward compatibility
+            # TODO: remove later
+            prop = f"{node}.openpype.{key}"
+            if not rv.commands.propertyExists(prop):
+                return
 
         value = rv.commands.getStringProperty(prop)[0]
         data[key] = value

--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -76,8 +76,7 @@ class OpenRVHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     def get_context_data(self):
         context_data = read("root", prefix=AYON_ATTR_PREFIX)
         if not context_data:
-            # lets try backward compatibility
-            # TODO: remove later
+            # backward compatibility
             context_data = read("root", prefix="openpype.")
 
         return context_data
@@ -211,8 +210,7 @@ def parse_container(node):
     for key in required:
         prop = f"{node}.{AYON_ATTR_PREFIX}{key}"
         if not rv.commands.propertyExists(prop):
-            # lets try backward compatibility
-            # TODO: remove later
+            # backward compatibility
             prop = f"{node}.openpype.{key}"
             if not rv.commands.propertyExists(prop):
                 return
@@ -237,8 +235,7 @@ def get_container_nodes():
         if rv.commands.propertyExists(prop):
             container_nodes.append(node)
         else:
-            # lets try backward compatibility
-            # TODO: remove later
+            # backward compatibility
             prop = f"{node}.openpype.schema"
             if rv.commands.propertyExists(prop):
                 container_nodes.append(node)

--- a/client/ayon_openrv/api/review.py
+++ b/client/ayon_openrv/api/review.py
@@ -34,12 +34,12 @@ def review_attributes(node=None):
 
 def get_review_attribute(node=None, attribute=None):
     # backward compatibility
-    attr = node + ".openpype" + "." + attribute
+    attr = node + ".ayon" + "." + attribute
     attr_value = rv.commands.getStringProperty(attr)[0]
 
     # TODO: remove this later
     if attr_value == "":
-        attr = node + ".ayon" + "." + attribute
+        attr = node + ".openpype" + "." + attribute
         attr_value = rv.commands.getStringProperty(attr)[0]
 
     return attr_value

--- a/client/ayon_openrv/api/review.py
+++ b/client/ayon_openrv/api/review.py
@@ -4,14 +4,14 @@ import os
 import rv
 
 
-def get_path_annotated_frame(frame=None, asset=None, asset_folder=None):
+def get_path_annotated_frame(frame=None, folder_name=None, folder_path=None):
     """Get path for annotations
     """
     # TODO: This should be less hardcoded
     filename = os.path.normpath(
         "{}/pyblish/exports/annotated_frames/annotate_{}_{}.jpg".format(
-            str(asset_folder),
-            str(asset),
+            str(folder_path),
+            str(folder_name),
             str(frame)
         )
     )
@@ -27,18 +27,26 @@ def extract_annotated_frame(filepath=None):
 
 def review_attributes(node=None):
     # TODO: Implement
-    # prop_status = node + ".openpype" + ".review_status"
-    # prop_comment = node + ".openpype" + ".review_comment"
+    # prop_status = node + ".ayon" + ".review_status"
+    # prop_comment = node + ".ayon" + ".review_comment"
     pass
 
 
 def get_review_attribute(node=None, attribute=None):
+    # backward compatibility
     attr = node + ".openpype" + "." + attribute
-    return rv.commands.getStringProperty(attr)[0]
+    attr_value = rv.commands.getStringProperty(attr)[0]
+
+    # TODO: remove this later
+    if attr_value == "":
+        attr = node + ".ayon" + "." + attribute
+        attr_value = rv.commands.getStringProperty(attr)[0]
+
+    return attr_value
 
 
 def write_review_attribute(node=None, attribute=None, att_value=None):
-    att_prop = node + ".openpype" + ".{}".format(attribute)
+    att_prop = node + ".ayon" + ".{}".format(attribute)
     if not rv.commands.propertyExists(att_prop):
         rv.commands.newProperty(att_prop, rv.commands.StringType, 1)
     rv.commands.setStringProperty(att_prop, [str(att_value)], True)

--- a/client/ayon_openrv/api/review.py
+++ b/client/ayon_openrv/api/review.py
@@ -37,7 +37,7 @@ def get_review_attribute(node=None, attribute=None):
     attr = node + ".ayon" + "." + attribute
     attr_value = rv.commands.getStringProperty(attr)[0]
 
-    # TODO: remove this later
+    # backward compatibility
     if attr_value == "":
         attr = node + ".openpype" + "." + attribute
         attr_value = rv.commands.getStringProperty(attr)[0]

--- a/client/ayon_openrv/api/review.py
+++ b/client/ayon_openrv/api/review.py
@@ -9,7 +9,7 @@ def get_path_annotated_frame(frame=None, folder_name=None, folder_path=None):
     """
     # TODO: This should be less hardcoded
     filename = os.path.normpath(
-        "{}/pyblish/exports/annotated_frames/annotate_{}_{}.jpg".format(
+        "{}/ayon/exports/annotated_frames/annotate_{}_{}.jpg".format(
             str(folder_path),
             str(folder_name),
             str(frame)

--- a/client/ayon_openrv/hooks/pre_ftrackdata.py
+++ b/client/ayon_openrv/hooks/pre_ftrackdata.py
@@ -16,4 +16,4 @@ class PreFtrackData(PreLaunchHook):
             with tempfile.NamedTemporaryFile(mode="w+", delete=False) as file:
                 json.dump(payload, file)
 
-            self.launch_context.env["OPENPYPE_LOADER_REPRESENTATIONS"] = str(file.name)  # noqa
+            self.launch_context.env["AYON_LOADER_REPRESENTATIONS"] = str(file.name)  # noqa

--- a/client/ayon_openrv/hooks/pre_setup_openrv.py
+++ b/client/ayon_openrv/hooks/pre_setup_openrv.py
@@ -25,13 +25,13 @@ class PreSetupOpenRV(PreLaunchHook):
         #   files that remain on disk but it does allow us to ensure RV is
         #   now running with the correct version of the RV packages of this
         #   current running AYON version
-        op_support_path = Path(tempfile.mkdtemp(
-            prefix="openpype_rv_support_path_"
+        ay_support_path = Path(tempfile.mkdtemp(
+            prefix="ayon_openrv_support_path_"
         ))
 
         # Write the AYON RV package zips directly to the support path
         # Packages/ folder then we don't need to `rvpkg -add` them afterwards
-        packages_dest_folder = op_support_path / "Packages"
+        packages_dest_folder = ay_support_path / "Packages"
         packages_dest_folder.mkdir(exist_ok=True)
         packages = ["comments", "ayon_menus", "ayon_scripteditor"]
         for package_name in packages:
@@ -42,19 +42,19 @@ class PreSetupOpenRV(PreLaunchHook):
             shutil.make_archive(str(package_dest), "zip", str(package_src))
 
         # Install and opt-in the AYON RV packages
-        install_args = [rvpkg, "-only", op_support_path, "-install", "-force"]
+        install_args = [rvpkg, "-only", ay_support_path, "-install", "-force"]
         install_args.extend(packages)
-        optin_args = [rvpkg, "-only", op_support_path, "-optin", "-force"]
+        optin_args = [rvpkg, "-only", ay_support_path, "-optin", "-force"]
         optin_args.extend(packages)
         run_subprocess(install_args, logger=self.log)
         run_subprocess(optin_args, logger=self.log)
 
-        self.log.debug(f"Adding RV_SUPPORT_PATH: {op_support_path}")
+        self.log.debug(f"Adding RV_SUPPORT_PATH: {ay_support_path}")
         support_path = self.launch_context.env.get("RV_SUPPORT_PATH")
         if support_path:
             support_path = os.pathsep.join([support_path,
-                                            str(op_support_path)])
+                                            str(ay_support_path)])
         else:
-            support_path = str(op_support_path)
+            support_path = str(ay_support_path)
         self.log.debug(f"Setting RV_SUPPORT_PATH: {support_path}")
         self.launch_context.env["RV_SUPPORT_PATH"] = support_path

--- a/client/ayon_openrv/plugins/create/create_workfile.py
+++ b/client/ayon_openrv/plugins/create/create_workfile.py
@@ -20,7 +20,7 @@ class OpenRVWorkfileCreator(AutoCreator):
     create_allow_context_change = False
 
     data_store_node = "root"
-    data_store_prefix = "openpype_workfile."
+    data_store_prefix = "ayon_workfile."
 
     def collect_instances(self):
 
@@ -29,9 +29,7 @@ class OpenRVWorkfileCreator(AutoCreator):
         if not data:
             return
 
-        product_name = data.get("productName")
-        if product_name is None:
-            product_name = data.get("subset")
+        product_name = data["productName"]
         instance = CreatedInstance(
             product_type=self.product_type,
             product_name=product_name,

--- a/client/ayon_openrv/plugins/load/openrv/load_frames.py
+++ b/client/ayon_openrv/plugins/load/openrv/load_frames.py
@@ -71,7 +71,7 @@ class FramesLoader(load.LoaderPlugin):
         rv.commands.setStringProperty(
             f"{node}.media.repName", ["repname"], allowResize=True)
         rv.commands.setStringProperty(
-            f"{node}.openpype.representation",
+            f"{node}.ayon.representation",
             [repre_entity["id"]], allowResize=True
         )
 

--- a/client/ayon_openrv/plugins/load/openrv/load_mov.py
+++ b/client/ayon_openrv/plugins/load/openrv/load_mov.py
@@ -56,7 +56,7 @@ class MovLoader(load.LoaderPlugin):
             f"{node}.media.repName", ["repname"], True
         )
         rv.commands.setStringProperty(
-            f"{node}.openpype.representation", [representation["id"]], True
+            f"{node}.ayon.representation", [representation["id"]], True
         )
 
     def remove(self, container):

--- a/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
+++ b/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
@@ -96,7 +96,7 @@ class AYONMenus(MinorMode):
 
 def data_loader():
     incoming_data_file = os.environ.get(
-        "OPENPYPE_LOADER_REPRESENTATIONS", None
+        "AYON_LOADER_REPRESENTATIONS", None
     )
     if incoming_data_file:
         with open(incoming_data_file, 'rb') as file:

--- a/client/ayon_openrv/startup/pkgs_source/comments/comments.py
+++ b/client/ayon_openrv/startup/pkgs_source/comments/comments.py
@@ -319,12 +319,6 @@ class ReviewMenu(MinorMode):
         import ftrack_api
         session = ftrack_api.Session(auto_connect_event_hub=False)
         self.log.debug("Ftrack user: \"{0}\"".format(session.api_user))
-        # project_name = legacy_io.Session["AVALON_PROJECT"]
-        # project_entity = session.query((
-        #     "select project_schema from Project where full_name is \"{}\""
-        # ).format(project_name)).one()
-        # project_schema = project_entity["project_schema"]
-
 
 def createMode():
     return ReviewMenu()

--- a/client/ayon_openrv/startup/pkgs_source/comments/comments.py
+++ b/client/ayon_openrv/startup/pkgs_source/comments/comments.py
@@ -208,7 +208,7 @@ class ReviewMenu(MinorMode):
     def setup_combo_status(self):
         # setup properties
         node = self.current_loaded_viewnode
-        att_prop = node + ".openpype_review.task_status"
+        att_prop = node + ".ayon_review.task_status"
         status = self.current_shot_status.currentText()
         rv.commands.setStringProperty(att_prop, [str(status)], True)
         self.current_shot_status.setCurrentText(status)
@@ -220,7 +220,7 @@ class ReviewMenu(MinorMode):
             self.current_shot_status.setCurrentIndex(0)
             return
 
-        att_prop = node + ".openpype_review.task_status"
+        att_prop = node + ".ayon_review.task_status"
         if not rv.commands.propertyExists(att_prop):
             status = "In Review"
             rv.commands.newProperty(att_prop, rv.commands.StringType, 1)
@@ -236,7 +236,7 @@ class ReviewMenu(MinorMode):
             return
 
         comment = self.current_shot_comment.toPlainText()
-        att_prop = node + ".openpype_review.task_comment"
+        att_prop = node + ".ayon_review.task_comment"
         rv.commands.newProperty(att_prop, rv.commands.StringType, 1)
         rv.commands.setStringProperty(att_prop, [str(comment)], True)
 
@@ -246,7 +246,7 @@ class ReviewMenu(MinorMode):
             self.current_shot_comment.setPlainText("")
             return
 
-        att_prop = node + ".openpype_review.task_comment"
+        att_prop = node + ".ayon_review.task_comment"
         if not rv.commands.propertyExists(att_prop):
             rv.commands.newProperty(att_prop, rv.commands.StringType, 1)
             rv.commands.setStringProperty(att_prop, [""], True)
@@ -257,8 +257,8 @@ class ReviewMenu(MinorMode):
     def clean_cmnt_status(self):
         attribs = []
         node = self.current_loaded_viewnode
-        att_prop_cmnt = node + ".openpype_review.task_comment"
-        att_prop_status = node + ".openpype_review.task_status"
+        att_prop_cmnt = node + ".ayon_review.task_comment"
+        att_prop_status = node + ".ayon_review.task_status"
         attribs.append(att_prop_cmnt)
         attribs.append(att_prop_status)
 

--- a/client/ayon_openrv/startup/pkgs_source/comments/comments.py
+++ b/client/ayon_openrv/startup/pkgs_source/comments/comments.py
@@ -196,7 +196,7 @@ class ReviewMenu(MinorMode):
         # Use namespace as loaded shot label
         namespace = ""
         if node is not None:
-            property_name = "{}.openpype.namespace".format(node)
+            property_name = "{}.ayon.namespace".format(node)
             if rv.commands.propertyExists(property_name):
                 namespace = rv.commands.getStringProperty(property_name)[0]
 


### PR DESCRIPTION
## Changelog Description

Updates the OpenRV integration to align with AYON's schema and naming conventions. This ensures compatibility and consistency with the AYON ecosystem.

- Updates attribute prefixes from `openpype` to `ayon`
- Uses `AYON_CONTAINER_ID` and `AYON_LOADER_REPRESENTATIONS`
- Updates review attribute handling for AYON compatibility

## Testing Notes
All should work as before. Open the app from launcher and then locate AYON menu on the top. Load some product version and see all is working as before. 