### PR TITLE
Latest OpenRV PySide6 updates

### DIFF
--- a/client/ayon_openrv/startup/pkgs_source/comments/comments.py
+++ b/client/ayon_openrv/startup/pkgs_source/comments/comments.py
@@ -7,7 +7,7 @@ import rv.commands
 import rv.qtutils
 
 from ayon_openrv.constants import AYON_ATTR_PREFIX
-from PySide2 import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 from rv.rvtypes import MinorMode
 
 
@@ -212,7 +212,7 @@ class ReviewMenu(MinorMode):
         else:
             return rv.commands.UncheckedMenuState
 
-    def set_item_font(self, item, size=14, noweight=False, bold=True):
+    def set_item_font(self, item, size=14, bold=True):
         font = QtGui.QFont()
         if bold:
             font.setFamily("Arial Bold")
@@ -220,8 +220,6 @@ class ReviewMenu(MinorMode):
             font.setFamily("Arial")
         font.setPointSize(size)
         font.setBold(True)
-        if not noweight:
-            font.setWeight(75)
         item.setFont(font)
 
     def on_frame_changed(self, event=None):

--- a/client/ayon_openrv/typing/rv/qtutils/__init__.py
+++ b/client/ayon_openrv/typing/rv/qtutils/__init__.py
@@ -1,7 +1,7 @@
 """Type hints for rv.qtutils module."""
 
 from typing import Any, Optional
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 
 
 def sessionWindow() -> QtWidgets.QMainWindow:


### PR DESCRIPTION
- Replaces direct `PySide2.QtWidgets` imports with `qtpy` for better cross-platform compatibility.
- Simplifies font settings in the `set_item_font` method by removing redundant logic.
- Adjusts minor documentation for type hints consistency.


## Testing notes
1. add OpenRV latest build from @antirotor into your Application addon OpenRV variants
2. open any thing from that new OpenRV variant.
3. AYON menu should look the same as before