### PR TITLE
Publish: Use new workfiles API to increment current workfile

### DIFF
--- a/client/ayon_openrv/plugins/publish/increment_workfile.py
+++ b/client/ayon_openrv/plugins/publish/increment_workfile.py
@@ -1,3 +1,5 @@
+import os
+
 import pyblish.api
 
 from ayon_core.lib import version_up
@@ -24,8 +26,34 @@ class IncrementWorkfile(pyblish.api.InstancePlugin):
                 "Skipping incrementing current file because publishing failed."
             )
 
-        scene_path = version_up(instance.context.data["currentFile"])
+        context = instance.context
+        current_filepath = instance.context.data["currentFile"]
         host = registered_host()
-        host.save_workfile(scene_path)
+        try:
+            from ayon_core.pipeline.workfile import save_next_version
+            from ayon_core.host.interfaces import SaveWorkfileOptionalData
 
-        self.log.info("Incremented workfile to: {}".format(scene_path))
+            current_filename = os.path.basename(current_filepath)
+            save_next_version(
+                description=(
+                    f"Incremented by publishing from {current_filename}"
+                ),
+                # Optimize the save by reducing needed queries for context
+                prepared_data=SaveWorkfileOptionalData(
+                    project_entity=context.data["projectEntity"],
+                    project_settings=context.data["project_settings"],
+                    anatomy=context.data["anatomy"],
+                )
+            )
+            new_filepath = host.get_current_workfile()
+
+        except ImportError:
+            # Backwards compatibility before ayon-core 1.5.0
+            self.log.debug(
+                "Using legacy `version_up`. Update AYON core addon to "
+                "use newer `save_next_version` function."
+            )
+            new_filepath = version_up(current_filepath)
+            host.save_workfile(new_filepath)
+
+        self.log.info(f"Incremented workfile to: {new_filepath}")


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

Test with ayon-core 1.5.0 (and also backwards compatibility against older releases)

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
5. Publishing should also still work and increment (the old way) with older ayon-core.
