### PR TITLE
Remove redundant `Host.__init__`

### DIFF
--- a/client/ayon_openrv/api/pipeline.py
+++ b/client/ayon_openrv/api/pipeline.py
@@ -28,10 +28,6 @@ JSON_PREFIX = "JSON:::"
 class OpenRVHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "openrv"
 
-    def __init__(self):
-        super(OpenRVHost, self).__init__()
-        self._ay_events = {}
-
     def install(self):
         pyblish.api.register_plugin_path(PUBLISH_PATH)
         pyblish.api.register_host("openrv")


### PR DESCRIPTION
## Changelog Description

Remove redundant `Host.__init__`

## Additional review information

Just cleanup.

## Testing notes:

1. Integration still works