### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_openrv/plugins/create/create_workfile.py
+++ b/client/ayon_openrv/plugins/create/create_workfile.py
@@ -13,6 +13,7 @@ from ayon_core.pipeline import (
 class OpenRVWorkfileCreator(AutoCreator):
     identifier = "workfile"
     product_type = "workfile"
+    product_base_type = "workfile"
     label = "Workfile"
 
     default_variant = "Main"


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.