### PR TITLE
feat(menus): make panel visibility state persistent across sessions

### DIFF
--- a/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
+++ b/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
@@ -182,14 +182,15 @@ class AYONMenus(MinorMode):
 
     def open_desktop_review_panel(self, panel_name: str, *_):
         panel = self.review_controller.get_panel(panel_name)
-        self.review_controller.set_project(get_current_project_name() or "")
-        self.review_controller.load_ayon_data()
         label = panel_name.replace("_", " ").capitalize()
         dock_widget = self.review_controller.set_docker_widget(
             self._parent, panel, label
         )
+        # get the data
+        self.review_controller.set_project(get_current_project_name() or "")
+        self.review_controller.load_ayon_data()
 
-        if panel_name not in self._connected_panels:
+        if dock_widget and panel_name not in self._connected_panels:
             filter_ = DockCloseFilter(
                 panel_name,
                 self._write_panel_startup_visibility,
@@ -197,6 +198,9 @@ class AYONMenus(MinorMode):
             )
             dock_widget.installEventFilter(filter_)
             self._connected_panels.add(panel_name)
+
+        # # allow panel to show now.
+        # QApplication.instance().processEvents()
 
     def add_desktop_review_menu_items(self, menu):
         # Check if addon is enabled


### PR DESCRIPTION
## Changelog Description
Add functionality to remember which panels were open and automatically restore them on startup. Panel visibility is stored in RV settings and read during initialization to reopen previously visible panels.

## Additional review information
None.

## Testing notes:
1. start with this step
2. follow this step
