### PR TITLE
feat(loaders): emit internal event when sources are loaded

### DIFF
--- a/client/ayon_openrv/plugins/load/openrv/load_frames.py
+++ b/client/ayon_openrv/plugins/load/openrv/load_frames.py
@@ -59,6 +59,10 @@ class FramesLoader(load.LoaderPlugin):
             loader=self.__class__.__name__,
         )
 
+        rv.commands.sendInternalEvent(
+            "ayon-source-loaded", str(node), "FramesLoader"
+        )
+
     def _finalize_loaded_node(self, loaded_node, rep_name, filepath):
         """Finalize the loaded node in OpenRV.
 

--- a/client/ayon_openrv/plugins/load/openrv/load_mov.py
+++ b/client/ayon_openrv/plugins/load/openrv/load_mov.py
@@ -50,6 +50,10 @@ class MovLoader(load.LoaderPlugin):
             loader=self.__class__.__name__,
         )
 
+        rv.commands.sendInternalEvent(
+            "ayon-source-loaded", str(node), "MovLoader"
+        )
+
     def _finalize_loaded_node(self, loaded_node, rep_name, filepath):
         """Finalize the loaded node in OpenRV.
 


### PR DESCRIPTION
## Changelog Description
Add "ayon-source-loaded" internal event dispatch to FramesLoader and MovLoader after successfully loading content. This enables other components to react when new sources are loaded into OpenRV.

## Additional review information
None

## Testing notes:
1. You will need the second part of that fix in ayon-review-desktop
