### PR TITLE
refactor(menus): pass panel name directly to docker widget

### DIFF
--- a/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
+++ b/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
@@ -198,9 +198,6 @@ class AYONMenus(MinorMode):
             dock_widget.installEventFilter(filter_)
             self._connected_panels.add(panel_name)
 
-        # # allow panel to show now.
-        # QApplication.instance().processEvents()
-
     def add_desktop_review_menu_items(self, menu):
         # Check if addon is enabled
         project_settings = get_project_settings(get_current_project_name())


### PR DESCRIPTION
## Changelog Description
Remove unnecessary string transformation of panel name before passing to set_docker_widget. Panel name is now used as-is without replacing underscores or capitalizing.
