### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_openrv/plugins/create/create_workfile.py
+++ b/client/ayon_openrv/plugins/create/create_workfile.py
@@ -12,7 +12,8 @@ from ayon_core.pipeline import (
 
 class OpenRVWorkfileCreator(AutoCreator):
     identifier = "workfile"
-    product_type = "workfile"
+    product_base_type = "workfile"
+    product_type = product_base_type
     label = "Workfile"
 
     default_variant = "Main"
@@ -31,6 +32,7 @@ class OpenRVWorkfileCreator(AutoCreator):
 
         product_name = data["productName"]
         instance = CreatedInstance(
+            product_base_type=self.product_base_type,
             product_type=self.product_type,
             product_name=product_name,
             data=data,
@@ -49,7 +51,7 @@ class OpenRVWorkfileCreator(AutoCreator):
     def create(self, options=None):
         existing_instance = None
         for instance in self.create_context.instances:
-            if instance.product_type == self.product_type:
+            if instance.product_base_type == self.product_base_type:
                 existing_instance = instance
                 break
 
@@ -92,7 +94,11 @@ class OpenRVWorkfileCreator(AutoCreator):
             ))
 
             new_instance = CreatedInstance(
-                self.product_type, product_name, data, self
+                product_base_type=self.product_base_type,
+                product_type=self.product_type,
+                product_name=product_name,
+                data=data,
+                creator=self,
             )
             self._add_instance_to_context(new_instance)
 

--- a/client/ayon_openrv/plugins/load/global/play_in_rv.py
+++ b/client/ayon_openrv/plugins/load/global/play_in_rv.py
@@ -19,7 +19,8 @@ class PlayInRV(load.LoaderPlugin):
     It expects to be run only on representations published to any task!
     """
 
-    product_types = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     representations = {"*"}
     extensions = {
         ext.lstrip(".")

--- a/client/ayon_openrv/plugins/load/openrv/load_frames.py
+++ b/client/ayon_openrv/plugins/load/openrv/load_frames.py
@@ -20,7 +20,8 @@ class FramesLoader(load.LoaderPlugin):
     """Load frames into OpenRV."""
 
     label = "Load Frames"
-    product_types: ClassVar[set] = {"*"}
+    product_base_types: ClassVar[set] = {"*"}
+    product_types = product_base_types
     representations: ClassVar[set] = {"*"}
     extensions: ClassVar[set] = {ext.lstrip(".") for ext in IMAGE_EXTENSIONS}
     order = 0

--- a/client/ayon_openrv/plugins/load/openrv/load_mov.py
+++ b/client/ayon_openrv/plugins/load/openrv/load_mov.py
@@ -16,7 +16,8 @@ class MovLoader(load.LoaderPlugin):
     """Load mov into OpenRV"""
 
     label = "Load MOV"
-    product_types: ClassVar[set] = {"*"}
+    product_base_types: ClassVar[set] = {"*"}
+    product_types = product_base_types
     representations: ClassVar[set] = {"*"}
     extensions: ClassVar[set] = {"mov", "mp4"}
     order = 0

--- a/package.py
+++ b/package.py
@@ -6,7 +6,7 @@ client_dir = "ayon_openrv"
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">=0.3.0",
+    "core": ">=1.8.0",
     "applications": ">=0.2.0",
 }
 ayon_compatible_addons = {}


### PR DESCRIPTION
## Changelog Description
Use product base types.

## Additional review information
Codebase of OpenRV addon is fully using product base type as "pipeline" type. Load plugins define `product_base_types` for filtering, create plugin does define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

At this moment there are no product type aliases, yet.

## Testing notes:
### Basics
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Existing workfiles should load up and should be possible to publish.
3. Publishing of workfiles works too.