### PR TITLE
Current file: Collect current file earlier

### DIFF
--- a/client/ayon_openrv/plugins/publish/collect_current_file.py
+++ b/client/ayon_openrv/plugins/publish/collect_current_file.py
@@ -1,4 +1,3 @@
-import os
 import pyblish.api
 
 from ayon_core.pipeline import registered_host

--- a/client/ayon_openrv/plugins/publish/collect_current_file.py
+++ b/client/ayon_openrv/plugins/publish/collect_current_file.py
@@ -1,0 +1,17 @@
+import os
+import pyblish.api
+
+from ayon_core.pipeline import registered_host
+
+
+class CollectCurrentFile(pyblish.api.ContextPlugin):
+    """Inject the current working file into context"""
+
+    order = pyblish.api.CollectorOrder - 0.5
+    label = "Collect Current File"
+    hosts = ["openrv"]
+
+    def process(self, context):
+        host = registered_host()
+        current_file = host.get_current_workfile() or ""
+        context.data["currentFile"] = current_file

--- a/client/ayon_openrv/plugins/publish/collect_workfile.py
+++ b/client/ayon_openrv/plugins/publish/collect_workfile.py
@@ -15,13 +15,9 @@ class CollectWorkfile(pyblish.api.InstancePlugin):
     def process(self, instance):
         """Inject the current working file"""
 
-        host = registered_host()
-        current_file = host.get_current_workfile() or ""
-
+        current_file = instance.context.data["currentFile"]
         folder, file = os.path.split(current_file)
         filename, ext = os.path.splitext(file)
-
-        instance.context.data["currentFile"] = current_file
 
         if not current_file:
             self.log.error("No current filepath detected. "

--- a/client/ayon_openrv/plugins/publish/collect_workfile.py
+++ b/client/ayon_openrv/plugins/publish/collect_workfile.py
@@ -1,8 +1,6 @@
 import os
 import pyblish.api
 
-from ayon_core.pipeline import registered_host
-
 
 class CollectWorkfile(pyblish.api.InstancePlugin):
     """Inject the current working file into context"""


### PR DESCRIPTION
## Changelog Description
Collect current file as soon as possible during publishing.

## Additional review information
Split existing collect workfile plugin into 2 plugins. New plugin only stores currentFile to context and the second is using it.
