### PR TITLE
Do not import Qt code in __init__

### DIFF
--- a/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
+++ b/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
@@ -204,11 +204,11 @@ class AYONMenus(MinorMode):
         review_desktop = project_settings.get("review_desktop", {})
         if not review_desktop.get("enabled", False):
             return
-        # import review desktop controler
+        # import review desktop controller
         try:
-            from ayon_review_desktop import ReviewController
+            from ayon_review_desktop.session_controller import ReviewController
         except ImportError:
-            print("Failed to import 'ayon_review_desktop':")
+            print("Failed to import 'ayon_review_desktop.session_controller':")
             traceback.print_exc()
             return
         # instance controler and return the menu items.


### PR DESCRIPTION
## Changelog Description
make sure init doesn't import any Qt code.

## Additional review information

Matching change for https://github.com/ynput/ayon-review-desktop/pull/66

## Testing notes:
1. start with this step
2. follow this step
