### PR TITLE
Open in RV web action as dynamic action

### DIFF
--- a/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
+++ b/client/ayon_openrv/startup/pkgs_source/ayon_menus/ayon_menus.py
@@ -168,6 +168,10 @@ class AYONMenus(MinorMode):
 
     def _open_visible_panels(self, event):
         event.reject()
+
+        if not getattr(self, "review_controller", None):
+            return
+
         self._panel_startup_visibility: list[str] = (
             self._read_panel_startup_visibility()
         )

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, TYPE_CHECKING
+from typing import Type, TYPE_CHECKING
 
 from ayon_server.actions import DynamicActionManifest
 from ayon_server.addons import BaseServerAddon

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,11 +1,12 @@
 from typing import Optional, Type, TYPE_CHECKING
 
-from ayon_server.actions import SimpleActionManifest
+from ayon_server.actions import DynamicActionManifest
 from ayon_server.addons import BaseServerAddon
 
 from .action import (
     execute_open_in_rv_action,
-    get_open_in_rv_simple_action,
+    get_open_in_rv_action,
+    can_open_in_rv,
 )
 from .settings import OpenRVSettings, DEFAULT_VALUES
 
@@ -20,12 +21,20 @@ class OpenRVAddon(BaseServerAddon):
         settings_model_cls = self.get_settings_model()
         return settings_model_cls(**DEFAULT_VALUES)
 
-    async def get_simple_actions(
+    async def get_dynamic_actions(
         self,
-        project_name: Optional[str] = None,
+        context,
         variant: str = "production",
-    ) -> list[SimpleActionManifest]:
-        return [get_open_in_rv_simple_action()]
+    ) -> list["DynamicActionManifest"]:
+        """Return dynamic actions for the given context.
+
+        The Open in RV action should only be shown when it is valid for the
+        selected version (i.e. when can_open_in_rv(context) is True).
+        """
+        actions = []
+        if await can_open_in_rv(context):
+            actions.append(get_open_in_rv_action())
+        return actions
 
     async def execute_action(
         self,

--- a/server/action.py
+++ b/server/action.py
@@ -1,10 +1,11 @@
 from typing import Optional, TYPE_CHECKING
 
-from ayon_server.actions import SimpleActionManifest
+from ayon_server.actions import DynamicActionManifest
 from ayon_server.addons.library import AddonLibrary
 from ayon_server.forms import SimpleForm
 from ayon_server.forms.simple_form import FormSelectOption
 from ayon_server.lib.postgres import Postgres
+from ayon_server.logging import logger
 
 if TYPE_CHECKING:
     from ayon_server.actions import ActionContext, ActionExecutor, ExecuteResponseModel
@@ -27,8 +28,8 @@ VIDEO_EXTENSIONS: frozenset[str] = frozenset({
 MEDIA_EXTENSIONS: frozenset[str] = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS
 
 
-def get_open_in_rv_simple_action() -> SimpleActionManifest:
-    return SimpleActionManifest(
+def get_open_in_rv_action() -> DynamicActionManifest:
+    return DynamicActionManifest(
         identifier=ACTION_IDENTIFIER,
         label="Open in RV",
         category="Desktop tools",
@@ -38,14 +39,14 @@ def get_open_in_rv_simple_action() -> SimpleActionManifest:
             "name": "live_tv",
             "color": "#FFA500",
         },
-        entity_type="version",
-        entity_subtypes=None,
-        allow_multiselection=False,
     )
 
 
 async def can_open_in_rv(context: "ActionContext") -> bool:
     """Return True if the action can run for the given context."""
+
+    logger.info(f"Checking if can be opened in context: {context}")
+
     project_name = context.project_name
     entity_ids = context.entity_ids or []
     if not project_name:


### PR DESCRIPTION
## Changelog Description

Open in RV web action as dynamic action.

## Additional review information

This requires the server and frontend to actually start serving the dynamic actions, which it doesn't currently. So would require a new server release first.

**⚠️ This currently does not work. ⚠️ ☝️** 

Fix #88 

## Testing notes:

1. Open in RV web action should show when relevant.
